### PR TITLE
Add ATR-based position sizing to live loop

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -5,7 +5,7 @@ import pandas as pd
 import ccxt
 from ta.momentum import RSIIndicator
 from ta.trend import MACD
-from ta.volatility import BollingerBands
+from ta.volatility import BollingerBands, AverageTrueRange
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -31,19 +31,31 @@ def add_indicators(df: pd.DataFrame) -> pd.DataFrame:
     rsi = RSIIndicator(close=df["close"], window=14)
     macd = MACD(close=df["close"])
     bb = BollingerBands(close=df["close"], window=20, window_dev=2)
+    atr = AverageTrueRange(high=df["high"], low=df["low"], close=df["close"], window=14)
     df["rsi"] = rsi.rsi()
     df["macd"] = macd.macd()
     df["macd_signal"] = macd.macd_signal()
     df["bb_high"] = bb.bollinger_hband()
     df["bb_low"] = bb.bollinger_lband()
     df["ret_1"] = df["close"].pct_change()
+    df["atr"] = atr.average_true_range()
     df.dropna(inplace=True)
     return df
 
 def make_supervised(df: pd.DataFrame, horizon:int=1, lookback:int=60) -> Tuple[np.ndarray,np.ndarray, pd.DataFrame]:
     df = df.copy()
     df["y"] = (df["close"].shift(-horizon) > df["close"]).astype(int)
-    feat_cols = ["close","volume","rsi","macd","macd_signal","bb_high","bb_low","ret_1"]
+    feat_cols = [
+        "close",
+        "volume",
+        "rsi",
+        "macd",
+        "macd_signal",
+        "bb_high",
+        "bb_low",
+        "ret_1",
+        "atr",
+    ]
     df.dropna(inplace=True)
     X_list, y_list = [], []
     values = df[feat_cols].values

--- a/main.py
+++ b/main.py
@@ -10,11 +10,27 @@ TIMEFRAME = os.getenv("TIMEFRAME","1m")
 LOOKBACK = int(os.getenv("LOOKBACK_WINDOW","60"))
 HORIZON = int(os.getenv("PREDICTION_HORIZON","1"))
 RISK_PER_TRADE = float(os.getenv("RISK_PER_TRADE","0.01"))
+ACCOUNT_BALANCE = float(os.getenv("ACCOUNT_BALANCE","10000"))
 
 def decide(prob_up: float, threshold: float=0.55) -> str:
     if prob_up >= threshold: return "LONG"
     if prob_up <= (1-threshold): return "SHORT"
     return "FLAT"
+
+def position_size(df, action: str, risk_per_trade: float, account_balance: float) -> dict:
+    atr = float(df["atr"].iloc[-1]) if "atr" in df.columns else 0.0
+    price = float(df["close"].iloc[-1])
+    risk_amount = account_balance * risk_per_trade
+    if action == "FLAT" or atr <= 0:
+        units = 0.0
+    else:
+        units = risk_amount / atr
+    return {
+        "units": float(units),
+        "notional": float(units * price),
+        "atr": float(atr),
+        "price": price,
+    }
 
 def backfill_and_train():
     X, y, _ = load_dataset(SYMBOL, TIMEFRAME, limit=2000, horizon=HORIZON, lookback=LOOKBACK)
@@ -33,14 +49,18 @@ def live_loop():
                 time.sleep(5); continue
             probs = model.predict(X_live[-1][None,...])[0]
             action = decide(float(probs[1]))
+            sizing = position_size(df, action, RISK_PER_TRADE, ACCOUNT_BALANCE)
             print(json.dumps({
                 "symbol": SYMBOL,
                 "timeframe": TIMEFRAME,
                 "prob_up": float(probs[1]),
                 "decision": action,
-                "ts": df.index[-1].isoformat()
+                "ts": df.index[-1].isoformat(),
+                "position_units": sizing["units"],
+                "position_notional": sizing["notional"],
+                "atr": sizing["atr"],
+                "price": sizing["price"],
             }))
-            # TODO: Implement real position sizing using RISK_PER_TRADE and ATR.
             # TODO: Add Telegram alerts on decision changes.
             # TODO: Add stop-loss/take-profit rules and order execution via ccxt once paper trading is verified.
             time.sleep(60)  # run each minute


### PR DESCRIPTION
## Summary
- compute Average True Range during feature engineering so the model and live loop have access to recent volatility
- introduce an ATR-based position sizing helper that respects configured risk per trade and account balance
- extend live loop telemetry with the calculated position sizing details

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e65f0982f88320a2a96b77e9de671f